### PR TITLE
Correct some problems with usage of pytz.timezone in datetime objects

### DIFF
--- a/obsplan/entity.py
+++ b/obsplan/entity.py
@@ -141,9 +141,8 @@ class Observer(object):
         for fmt in formats:
             try:
                 date = datetime.strptime(date_str, fmt)
-                timetup = tuple(date.timetuple()[:6])
-                # re-express as timezone
-                date = datetime(*timetup, tzinfo=timezone)
+                # Localize to the requested timezone
+                date = timezone.localize(date)
                 return date
 
             except ValueError as e:
@@ -349,8 +348,8 @@ class Observer(object):
     def local2utc(self, date_s):
         """Convert local time to UTC"""
         y, m, d = date_s.split('/')
-        tlocal = datetime(int(y), int(m), int(d), 12, 0, 0,
-                          tzinfo=self.tz_local)
+        tlocal = datetime(int(y), int(m), int(d), 12, 0, 0)
+        tlocal = self.tz_local.localize(tlocal)
         r_date = ephem.Date(tlocal.astimezone(self.tz_utc))
         return r_date
 

--- a/obsplan/plots/airmass.py
+++ b/obsplan/plots/airmass.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
 
     start_time = datetime.strptime("2015-03-30 18:30:00",
                                    "%Y-%m-%d %H:%M:%S")
-    start_time = start_time.replace(tzinfo=tz)
+    start_time = tz.localize(start_time)
     t = start_time
     # if schedule starts after midnight, change start date to the
     # day before

--- a/obsplan/plots/polarsky.py
+++ b/obsplan/plots/polarsky.py
@@ -168,7 +168,7 @@ if __name__ == '__main__':
 
     start_time = datetime.strptime("2015-03-27 20:05:00",
                                    "%Y-%m-%d %H:%M:%S")
-    start_time = start_time.replace(tzinfo=tz)
+    start_time = tz.localize(start_time)
 
     plot.plot_targets(site, [entity.moon, entity.sun, tgt3],
                       start_time, ['white', 'yellow', 'green'])

--- a/obsplan/tests/test_entity.py
+++ b/obsplan/tests/test_entity.py
@@ -30,7 +30,8 @@ class TestEntity01(unittest.TestCase):
 
     def test_get_date0(self):
         time1 = self.obs.get_date("2014-04-15 19:00")
-        time2 = datetime(2014, 04, 15, 19, 0, 0, tzinfo=self.hst)
+        time2 = datetime(2014, 04, 15, 19, 0, 0)
+        time2 = self.hst.localize(time2)
         self.assert_(time1 == time2)
 
     def test_get_date1(self):
@@ -47,8 +48,8 @@ class TestEntity01(unittest.TestCase):
     def test_observable_1(self):
         # vega should be visible during this period
         tgt = entity.StaticTarget(name="vega", ra=vega[0], dec=vega[1])
-        time1 = self.obs.get_date("2014-04-29 04:00")
-        time2 = self.obs.get_date("2014-04-29 05:00")
+        time1 = self.obs.get_date("2014-04-29 04:30")
+        time2 = self.obs.get_date("2014-04-29 05:30")
         is_obs, t1, t2 = self.obs.observable(tgt, time1, time2,
                                              15.0, 85.0, 59.9*60)
         ## print((1, is_obs,
@@ -60,8 +61,8 @@ class TestEntity01(unittest.TestCase):
         # vega should be visible near the end but not in the beginning
         # during this period (rising)
         tgt = entity.StaticTarget(name="vega", ra=vega[0], dec=vega[1])
-        time1 = self.obs.get_date("2014-04-28 22:00")
-        time2 = self.obs.get_date("2014-04-28 23:00")
+        time1 = self.obs.get_date("2014-04-28 22:30")
+        time2 = self.obs.get_date("2014-04-28 23:30")
         is_obs, t1, t2 = self.obs.observable(tgt, time1, time2, 15.0, 85.0,
                                              60*45)  # 45 min ok
         self.assert_(is_obs == True)
@@ -70,8 +71,8 @@ class TestEntity01(unittest.TestCase):
         # vega should be visible near the end but not in the beginning
         # during this period (rising)
         tgt = entity.StaticTarget(name="vega", ra=vega[0], dec=vega[1])
-        time1 = self.obs.get_date("2014-04-28 22:00")
-        time2 = self.obs.get_date("2014-04-28 23:00")
+        time1 = self.obs.get_date("2014-04-28 22:30")
+        time2 = self.obs.get_date("2014-04-28 23:30")
         is_obs, t1, t2 = self.obs.observable(tgt, time1, time2, 15.0, 85.0,
                                               60*50)  # 50 min NOT ok
         self.assert_(is_obs == False)
@@ -80,8 +81,8 @@ class TestEntity01(unittest.TestCase):
         # vega should be visible near the beginning but not near the end
         # during this period (setting)
         tgt = entity.StaticTarget(name="vega", ra=vega[0], dec=vega[1])
-        time1 = self.obs.get_date("2014-04-29 09:00")
-        time2 = self.obs.get_date("2014-04-29 10:00")
+        time1 = self.obs.get_date("2014-04-29 09:30")
+        time2 = self.obs.get_date("2014-04-29 10:30")
         is_obs, t1, T2 = self.obs.observable(tgt, time1, time2, 15.0, 85.0,
                                              60*30)  # 30 min ok
         self.assert_(is_obs == True)
@@ -90,8 +91,8 @@ class TestEntity01(unittest.TestCase):
         # vega should be visible near the beginning but not near the end
         # during this period (setting)
         tgt = entity.StaticTarget(name="vega", ra=vega[0], dec=vega[1])
-        time1 = self.obs.get_date("2014-04-29 09:00")
-        time2 = self.obs.get_date("2014-04-29 10:00")
+        time1 = self.obs.get_date("2014-04-29 09:30")
+        time2 = self.obs.get_date("2014-04-29 10:30")
         is_obs, t1, t2 = self.obs.observable(tgt, time1, time2, 15.0, 85.0,
                                              60*45)  # 45 min NOT ok
         self.assert_(is_obs == False)
@@ -100,8 +101,8 @@ class TestEntity01(unittest.TestCase):
         # vega should be visible near the beginning but not near the end
         # during this period (setting)
         tgt = entity.StaticTarget(name="vega", ra=vega[0], dec=vega[1])
-        time1 = self.obs.get_date("2014-04-29 09:30")
-        time2 = self.obs.get_date("2014-04-29 10:30")
+        time1 = self.obs.get_date("2014-04-29 10:00")
+        time2 = self.obs.get_date("2014-04-29 11:00")
         is_obs, t1, t2 = self.obs.observable(tgt, time1, time2, 15.0, 85.0,
                                              60*15)  # 15 min NOT ok
         self.assert_(is_obs == False)
@@ -117,7 +118,7 @@ class TestEntity01(unittest.TestCase):
     def test_distance_1(self):
         tgt1 = entity.StaticTarget(name="vega", ra=vega[0], dec=vega[1])
         tgt2 = entity.StaticTarget(name="altair", ra=altair[0], dec=altair[1])
-        time1 = self.obs.get_date("2010-10-18 22:00")
+        time1 = self.obs.get_date("2010-10-18 22:30")
         d_alt, d_az = self.obs.distance(tgt1, tgt2, time1)
         self.assertEquals(str(d_alt)[:7], '-9.9657')
         self.assertEquals(str(d_az)[:7], '36.1910')


### PR DESCRIPTION
- Original use of pytz.timezone resulted in the UTC offset to US/Hawaii
  being -10:30 instead of the correct -10:00. As a result, after
  making corrections, had to adjust timestamps in test_entity by
  30 minutes ahead to compensate.
